### PR TITLE
Use viewBox attribute over size defined on iconset

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -175,13 +175,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _prepareSvgClone: function(sourceSvg, size) {
       if (sourceSvg) {
-        var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        svg.setAttribute('viewBox', ['0', '0', size, size].join(' '));
+        var content = sourceSvg.cloneNode(true),
+            svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+            viewBox = content.getAttribute('viewBox') || '0 0 ' + size + ' ' + size;
+        svg.setAttribute('viewBox', viewBox);
         svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
         // TODO(dfreedm): `pointer-events: none` works around https://crbug.com/370136
         // TODO(sjmiles): inline style may not be ideal, but avoids requiring a shadow-root
         svg.style.cssText = 'pointer-events: none; display: block; width: 100%; height: 100%;';
-        svg.appendChild(sourceSvg.cloneNode(true)).removeAttribute('id');
+        svg.appendChild(content).removeAttribute('id');
         return svg;
       }
       return null;

--- a/test/iron-iconset-svg.html
+++ b/test/iron-iconset-svg.html
@@ -41,6 +41,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <defs>
             <circle id="circle" cx="20" cy="20" r="10"></circle>
             <rect id="square" x="0" y="0" width="20" height="20"></rect>
+            <symbol id="rect" viewBox="0 0 50 25">
+              <rect x="0" y="0" width="50" height="25"></rect>
+            </symbol>
           </defs>
         </svg>
       </iron-iconset-svg>
@@ -84,7 +87,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('can be queried for all available icons', function () {
-          expect(iconset.getIconNames()).to.deep.eql(['my-icons:circle', 'my-icons:square']);
+          expect(iconset.getIconNames()).to.deep.eql(['my-icons:circle', 'my-icons:square', 'my-icons:rect']);
         });
 
         test('supports any icon defined in the svg', function () {
@@ -95,6 +98,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(div.firstElementChild).to.not.be.equal(lastSvgIcon);
             lastSvgIcon = div.firstElementChild;
           });
+        });
+
+        test('prefers a viewBox attribute over the iconset size', function () {
+          iconset.applyIcon(div, 'rect');
+          expect(div.firstElementChild.getAttribute('viewBox')).to.be.equal('0 0 50 25');
+        });
+
+        test('uses the iconset size when viewBox is not defined on the element', function () {
+          iconset.applyIcon(div, 'circle');
+          expect(div.firstElementChild.getAttribute('viewBox')).to.be.equal('0 0 20 20');
         });
 
       });


### PR DESCRIPTION
If a viewBox attribute exists on the source svg
element then use it, otherwise fall back to the size
defined on the iconset.

This allows icons to be shapes other than square, and
allows each icon within a given set to define it's own
viewBox size.

When the viewBox attribute is used, sizing/scaling icons
relative to one another is the responsibility of the user.