### PR TITLE
Dispatch an event on window when the iconset loads.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "paper-styles": "polymerelements/paper-styles#^1.0.2",
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
     "iron-icon": "polymerelements/iron-icon#^1.0.0",
+    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "web-component-tester": "*"

--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -136,6 +136,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _nameChanged: function() {
       new Polymer.IronMeta({type: 'iconset', key: this.name, value: this});
+      this.async(function() {
+        this.fire('iron-iconset-added', this, {node: window});
+      });
     },
 
     /**

--- a/test/iron-iconset-svg.html
+++ b/test/iron-iconset-svg.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../iron-iconset-svg.html">
   <link rel="import" href="../../iron-meta/iron-meta.html">
+  <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
 
 </head>
@@ -55,8 +56,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('basic behavior', function () {
         var iconset;
         var meta;
+        var loadedPromise;
 
         setup(function () {
+          loadedPromise = new Promise(function(resolve) {
+            window.addEventListener('iron-iconset-added', function(ev) {
+              if (ev && ev.detail === iconset) {
+                resolve();
+              }
+            });
+          });
           var elements = fixture('TrivialIconsetSvg');
           iconset = elements[0];
           meta = elements[1];
@@ -64,6 +73,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('it can be accessed via iron-meta', function () {
           expect(meta.byKey('foo')).to.be.equal(iconset);
+        });
+
+        test('it fires an iron-iconset-added event on the window', function() {
+          return loadedPromise;
         });
       });
 


### PR DESCRIPTION
This will enable iron-icons to detect when an iconset loads after the icon element itself.

Related to https://github.com/PolymerElements/iron-icons/issues/18