### PR TITLE
Fix icon removal when using shady DOM

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -120,6 +120,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     removeIcon: function(element) {
       // Remove old svg element
+      element = element.root || element;
       if (element._svgIcon) {
         Polymer.dom(element).removeChild(element._svgIcon);
         element._svgIcon = null;

--- a/test/iron-iconset-svg.html
+++ b/test/iron-iconset-svg.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../iron-iconset-svg.html">
   <link rel="import" href="../../iron-meta/iron-meta.html">
+  <link rel="import" href="../../iron-icon/iron-icon.html">
   <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
 
@@ -49,6 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </svg>
       </iron-iconset-svg>
       <div></div>
+      <iron-icon></iron-icon>
     </template>
   </test-fixture>
 
@@ -133,6 +135,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('uses the iconset size when viewBox is not defined on the element', function () {
           iconset.applyIcon(div, 'circle');
           expect(div.firstElementChild.getAttribute('viewBox')).to.be.equal('0 0 20 20');
+        });
+      });
+
+      suite('Adding / removal from iron-icon', function () {
+        var iconset;
+        var div;
+        var ironIcon;
+
+        setup(function () {
+          var elements = fixture('StandardIconsetSvg');
+          iconset = elements[0];
+          div = elements[1];
+          ironIcon = elements[2];
+        });
+
+        test('be able to remove an iconset from a standard DOM element', function () {
+          iconset.applyIcon(div, 'circle');
+          Polymer.dom.flush()
+          expect(div.children.length).to.be.equal(1);
+          iconset.removeIcon(div);
+          Polymer.dom.flush()
+          expect(div.children.length).to.be.equal(0);
+        });
+
+        test('be able to remove an iconset from a Polymer element', function () {
+          var baseLength = Polymer.dom(ironIcon.root).children.length;
+          iconset.applyIcon(ironIcon, 'circle');
+          Polymer.dom.flush()
+          expect(Polymer.dom(ironIcon.root).children.length - baseLength).to.be.equal(1);
+          iconset.removeIcon(ironIcon);
+          Polymer.dom.flush()
+          expect(Polymer.dom(ironIcon.root).children.length - baseLength).to.be.equal(0);
         });
 
       });


### PR DESCRIPTION
When clearing the icon from an `iron-icon` element, the local dom isn't cleared properly on browsers not supporting shadow DOM natively (Safari, Edge, IE).

This is due to the fact that `removeIcon` doesn't try to access to the element's local DOM root whereas `applyIcon` does.

This PR makes both method behave the same way