### PR TITLE
preventing SVGs in IE/Edge from receiving tab focus

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -181,6 +181,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             viewBox = content.getAttribute('viewBox') || '0 0 ' + size + ' ' + size;
         svg.setAttribute('viewBox', viewBox);
         svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+        svg.setAttribute('focusable', 'false');
         // TODO(dfreedm): `pointer-events: none` works around https://crbug.com/370136
         // TODO(sjmiles): inline style may not be ideal, but avoids requiring a shadow-root
         svg.style.cssText = 'pointer-events: none; display: block; width: 100%; height: 100%;';

--- a/test/iron-iconset-svg.html
+++ b/test/iron-iconset-svg.html
@@ -135,6 +135,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(div.firstElementChild.getAttribute('viewBox')).to.be.equal('0 0 20 20');
         });
 
+        test('prevents SVG from receiving a tab stop in IE/Edge', function() {
+            iconset.applyIcon(div, 'rect');
+            expect(div.firstElementChild.getAttribute('focusable')).to.be.equal('false');
+        });
+
       });
 
     });


### PR DESCRIPTION
This fixes #46 by setting the `focusable` attribute on the SVG to `false`, which prevents SVG elements from receiving tab focus as the user tabs around the page in IE and Edge.

Information on the `focusable` attribute from the SVG W3C spec:
https://www.w3.org/TR/SVGTiny12/interact.html#focusable-attr

Stack Overflow discussion of this fix:
http://stackoverflow.com/questions/18646111/disable-onfocus-event-for-svg-element
