### PR TITLE
Support icon mirroring in RTL contexts.

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -79,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    _targetIsRTL(target) {
+    _targetIsRTL: function(target) {
       if (target && target.nodeType !== Node.ELEMENT_NODE) {
         target = target.host;
       }
@@ -201,7 +201,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             cssText = 'pointer-events: none; display: block; width: 100%; height: 100%;';
 
         if (mirrorAllowed && content.hasAttribute('mirror-in-rtl')) {
-          cssText += 'transform:scale(-1,1);';
+          cssText += '-webkit-transform:scale(-1,1);transform:scale(-1,1);';
         }
 
         svg.setAttribute('viewBox', viewBox);

--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -66,8 +66,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       size: {
         type: Number,
         value: 24
+      },
+
+      /**
+       * Set to true to enable mirroring of icons where specified when they are
+       * stamped. Icons that should be mirrored should be decorated with a
+       * `mirror-in-rtl` attribute.
+       */
+      rtlMirroring: {
+        type: Boolean,
+        value: false
+      }
+    },
+
+    _targetIsRTL(target) {
+      if (target && target.nodeType !== Node.ELEMENT_NODE) {
+        target = target.host;
       }
 
+      return target && window.getComputedStyle(target)['direction'] === 'rtl';
     },
 
     attached: function() {
@@ -103,7 +120,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Remove old svg element
       this.removeIcon(element);
       // install new svg element
-      var svg = this._cloneIcon(iconName);
+      var svg = this._cloneIcon(iconName,
+          this.rtlMirroring && this._targetIsRTL(element));
       if (svg) {
         var pde = Polymer.dom(element);
         pde.insertBefore(svg, pde.childNodes[0]);
@@ -162,28 +180,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {Element} Returns an installable clone of the SVG element
      * matching `id`.
      */
-    _cloneIcon: function(id) {
+    _cloneIcon: function(id, mirrorAllowed) {
       // create the icon map on-demand, since the iconset itself has no discrete
       // signal to know when it's children are fully parsed
       this._icons = this._icons || this._createIconMap();
-      return this._prepareSvgClone(this._icons[id], this.size);
+      return this._prepareSvgClone(this._icons[id], this.size, mirrorAllowed);
     },
 
     /**
      * @param {Element} sourceSvg
      * @param {number} size
+     * @param {Boolean} mirrorAllowed
      * @return {Element}
      */
-    _prepareSvgClone: function(sourceSvg, size) {
+    _prepareSvgClone: function(sourceSvg, size, mirrorAllowed) {
       if (sourceSvg) {
         var content = sourceSvg.cloneNode(true),
             svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
-            viewBox = content.getAttribute('viewBox') || '0 0 ' + size + ' ' + size;
+            viewBox = content.getAttribute('viewBox') || '0 0 ' + size + ' ' + size,
+            cssText = 'pointer-events: none; display: block; width: 100%; height: 100%;';
+
+        if (mirrorAllowed && content.hasAttribute('mirror-in-rtl')) {
+          cssText += 'transform:scale(-1,1);';
+        }
+
         svg.setAttribute('viewBox', viewBox);
         svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
         // TODO(dfreedm): `pointer-events: none` works around https://crbug.com/370136
         // TODO(sjmiles): inline style may not be ideal, but avoids requiring a shadow-root
-        svg.style.cssText = 'pointer-events: none; display: block; width: 100%; height: 100%;';
+        svg.style.cssText = cssText;
         svg.appendChild(content).removeAttribute('id');
         return svg;
       }
@@ -191,4 +216,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
   });
+
 </script>

--- a/test/iron-iconset-svg.html
+++ b/test/iron-iconset-svg.html
@@ -35,6 +35,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="MirroredIconsetSvg">
+    <template>
+      <iron-iconset-svg name="mirrored-icons" rtl-mirroring>
+        <circle id="circle" cx="20" cy="20" r="10"></circle>
+        <symbol id="rect" viewBox="0 0 50 25" mirror-in-rtl>
+          <rect x="0" y="0" width="50" height="25"></rect>
+        </symbol>
+      </iron-iconset-svg>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="RtlContainer">
+    <template>
+      <div dir="rtl"></div>
+    </template>
+  </test-fixture>
+
   <test-fixture id="StandardIconsetSvg">
     <template>
       <iron-iconset-svg name="my-icons" size="20">
@@ -86,6 +103,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('it fires an iron-iconset-added event on the window', function() {
           return loadedPromise;
+        });
+      });
+
+      suite('when stamping in an RTL context', function() {
+        var iconset;
+        var rtlContainer;
+
+        setup(function() {
+          iconset = fixture('MirroredIconsetSvg');
+          rtlContainer = fixture('RtlContainer');
+        });
+
+        test('icons marked as mirror-in-rtl are mirrored', function() {
+          iconset.applyIcon(rtlContainer, 'rect');
+          var svg = rtlContainer.firstElementChild;
+          var computedStyle = window.getComputedStyle(svg);
+          var transform = computedStyle.transform || computedStyle.webkitTransform;
+          expect(transform).to.be.eql('matrix(-1, 0, 0, 1, 0, 0)');
+        });
+
+        test('icons not marked as mirror-in-rtl are not mirrored', function() {
+          iconset.applyIcon(rtlContainer, 'circle');
+          var svg = rtlContainer.firstElementChild;
+          var computedStyle = window.getComputedStyle(svg);
+          var transform = computedStyle.transform || computedStyle.webkitTransform;
+          expect(transform).to.be.eql('none');
         });
       });
 


### PR DESCRIPTION
This change adds the ability to mark an `iron-iconset-svg` as `rtl-mirroring`. This means that when the iconset stamps its icons, it will check for a special attribute in each source icon (`mirror-in-rtl`). If such an attribute is present, it will then mirror the icon across the Y axis.

The rationale for two tiers of configuration to make this happen is that A) it will help ensure no-one has a regression due to this change and B) it will help keep the performance impact of measuring the `direction` of an icon's target parent down.

There is a companion PR that must be merged against `iron-icon` to support this new behavior here: https://github.com/PolymerElements/iron-icon/pull/82

Fixes #53 