### PR TITLE
defer getting computed direction until it's needed

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -120,8 +120,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Remove old svg element
       this.removeIcon(element);
       // install new svg element
-      var svg = this._cloneIcon(iconName,
-          this.rtlMirroring && this._targetIsRTL(element));
+      var svg = this._cloneIcon(iconName, element);
       if (svg) {
         var pde = Polymer.dom(element);
         pde.insertBefore(svg, pde.childNodes[0]);
@@ -180,27 +179,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {Element} Returns an installable clone of the SVG element
      * matching `id`.
      */
-    _cloneIcon: function(id, mirrorAllowed) {
+    _cloneIcon: function(id, target) {
       // create the icon map on-demand, since the iconset itself has no discrete
       // signal to know when it's children are fully parsed
       this._icons = this._icons || this._createIconMap();
-      return this._prepareSvgClone(this._icons[id], this.size, mirrorAllowed);
+      return this._prepareSvgClone(this._icons[id], this.size, target);
     },
 
     /**
      * @param {Element} sourceSvg
      * @param {number} size
-     * @param {Boolean} mirrorAllowed
+     * @param {Element} target
      * @return {Element}
      */
-    _prepareSvgClone: function(sourceSvg, size, mirrorAllowed) {
+    _prepareSvgClone: function(sourceSvg, size, target) {
       if (sourceSvg) {
         var content = sourceSvg.cloneNode(true),
             svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
             viewBox = content.getAttribute('viewBox') || '0 0 ' + size + ' ' + size,
             cssText = 'pointer-events: none; display: block; width: 100%; height: 100%;';
 
-        if (mirrorAllowed && content.hasAttribute('mirror-in-rtl')) {
+        if (this.rtlMirroring && content.hasAttribute('mirror-in-rtl') && this._targetIsRTL(target)) {
           cssText += '-webkit-transform:scale(-1,1);transform:scale(-1,1);';
         }
 


### PR DESCRIPTION
This change defers the `window.getComputedStyle(target)['direction']` so that this check can be avoided for icons that will not be mirrored.  In the original implementation, an iconset with `rtl-mirroring` would perform the `getComputedStyle` call for all icons in the set, regardless of whether the icon requires mirroring in an RTL context.
