### PR TITLE
Fix IronMeta 1.x not working with iron-iconset-svg

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
-    "iron-meta": "PolymerElements/iron-meta#1 - 2"
+    "iron-meta": "PolymerElements/iron-meta#^2.0.0"
   },
   "devDependencies": {
     "paper-styles": "PolymerElements/paper-styles#1 - 2",


### PR DESCRIPTION
I think the following line breaks backward compatibility with IronMeta 1.x:
https://github.com/PolymerElements/iron-iconset-svg/blob/master/iron-iconset-svg.html#L176

We should be forcing IronMeta 2.x and disallowing 1.x.

See bug #69
https://github.com/PolymerElements/iron-iconset-svg/issues/69