### PR TITLE
Preventing SVGs in IE/Edge from receiving tab focus for 1.x

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -227,6 +227,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         svg.setAttribute('viewBox', viewBox);
         svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+        svg.setAttribute('focusable', 'false');
         // TODO(dfreedm): `pointer-events: none` works around https://crbug.com/370136
         // TODO(sjmiles): inline style may not be ideal, but avoids requiring a shadow-root
         svg.style.cssText = cssText;


### PR DESCRIPTION
@bicknellr 
Copy of pull request https://github.com/PolymerElements/iron-iconset-svg/pull/47 for the 1.x branch. 

Please merge into 1.x branch, tag and release.