### PR TITLE
Add global-only RTL mirroring.

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -80,6 +80,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       rtlMirroring: {
         type: Boolean,
         value: false
+      },
+
+      /**
+       * Set to true to measure RTL based on the dir attribute on the body or
+       * html elements (measured on document.body or document.documentElement as
+       * available).
+       */
+      useGlobalRtlAttribute: {
+        type: Boolean,
+        value: false
       }
     },
 
@@ -156,12 +166,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _targetIsRTL: function(target) {
       if (this.__targetIsRTL == null) {
-        if (target && target.nodeType !== Node.ELEMENT_NODE) {
-          target = target.host;
-        }
+        if (this.useGlobalRtlAttribute) {
+          var globalElement =
+              (document.body && document.body.hasAttribute('dir'))
+                  ? document.body
+                  : document.documentElement;
 
-        this.__targetIsRTL = target &&
-            window.getComputedStyle(target)['direction'] === 'rtl';
+          this.__targetIsRTL = globalElement.getAttribute('dir') === 'rtl';
+        } else {
+          if (target && target.nodeType !== Node.ELEMENT_NODE) {
+            target = target.host;
+          }
+
+          this.__targetIsRTL = target &&
+              window.getComputedStyle(target)['direction'] === 'rtl';
+        }
       }
 
       return this.__targetIsRTL;

--- a/test/iron-iconset-svg.html
+++ b/test/iron-iconset-svg.html
@@ -47,6 +47,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="GloballyMirroredIconsetSVG">
+    <template>
+      <iron-iconset-svg name="globally-mirrored-icons" rtl-mirroring use-global-rtl-attribute>
+        <circle id="circle" cx="20" cy="20" r="10"></circle>
+        <symbol id="rect" viewBox="0 0 50 25" mirror-in-rtl>
+          <rect x="0" y="0" width="50" height="25"></rect>
+        </symbol>
+      </iron-iconset-svg>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="DefaultContainer">
+    <template>
+      <dir></div>
+    </template>
+  </test-fixture>
+
   <test-fixture id="RtlContainer">
     <template>
       <div dir="rtl"></div>
@@ -73,9 +90,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
 
-    suite('<iron-iconset>', function () {
 
-      suite('basic behavior', function () {
+    suite('<iron-iconset>', function() {
+
+      suite('basic behavior', function() {
         var iconset;
         var meta;
         var loadedPromise;
@@ -109,39 +127,71 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('when stamping in an RTL context', function() {
-        var iconset;
-        var rtlContainer;
 
-        setup(function() {
-          iconset = fixture('MirroredIconsetSvg');
-          rtlContainer = fixture('RtlContainer');
-        });
+        var rtlSuite = function(iconsetFixture, iconContainerFixture) {
+          var iconset;
+          var iconContainer;
 
-        test('icons marked as mirror-in-rtl are mirrored', function() {
-          iconset.applyIcon(rtlContainer, 'rect');
-          var svg = rtlContainer.firstElementChild;
-          var computedStyle = window.getComputedStyle(svg);
-          var transform = computedStyle.transform || computedStyle.webkitTransform;
-          expect(transform).to.be.eql('matrix(-1, 0, 0, 1, 0, 0)');
-        });
+          setup(function() {
+            iconset = fixture(iconsetFixture);
+            iconContainer = fixture(iconContainerFixture);
+          });
 
-        test('icons not marked as mirror-in-rtl are not mirrored', function() {
-          iconset.applyIcon(rtlContainer, 'circle');
-          var svg = rtlContainer.firstElementChild;
-          var computedStyle = window.getComputedStyle(svg);
-          var transform = computedStyle.transform || computedStyle.webkitTransform;
-          expect(transform).to.be.eql('none');
-        });
+          test('icons marked as mirror-in-rtl are mirrored', function() {
+            iconset.applyIcon(iconContainer, 'rect');
+            var svg = iconContainer.firstElementChild;
+            var computedStyle = window.getComputedStyle(svg);
+            var transform = computedStyle.transform || computedStyle.webkitTransform;
+            expect(transform).to.be.eql('matrix(-1, 0, 0, 1, 0, 0)');
+          });
 
-        test('many mirrored icons only call getComputedStyle once', function() {
-          sinon.spy(window, 'getComputedStyle');
+          test('icons not marked as mirror-in-rtl are not mirrored', function() {
+            iconset.applyIcon(iconContainer, 'circle');
+            var svg = iconContainer.firstElementChild;
+            var computedStyle = window.getComputedStyle(svg);
+            var transform = computedStyle.transform || computedStyle.webkitTransform;
+            expect(transform).to.be.eql('none');
+          });
 
-          for (var i = 0; i < 3; ++i) {
-            iconset.applyIcon(rtlContainer, 'rect');
-          }
+          test('getComputedStyle is called no more once for all icons', function() {
+            sinon.spy(window, 'getComputedStyle');
 
-          expect(window.getComputedStyle.callCount).to.be.eql(1);
-          window.getComputedStyle.restore();
+            for (var i = 0; i < 3; ++i) {
+              iconset.applyIcon(iconContainer, 'rect');
+            }
+
+            expect(window.getComputedStyle.callCount).to.be.lessThan(2);
+            window.getComputedStyle.restore();
+          });
+        };
+
+        rtlSuite('MirroredIconsetSvg', 'RtlContainer');
+
+        suite('when preferring the global RTL attribute', function() {
+
+          suite('and dir="rtl" on <body>', function() {
+            setup(function() {
+              document.body.setAttribute('dir', 'rtl');
+            });
+
+            teardown(function() {
+              document.body.removeAttribute('dir');
+            });
+
+            rtlSuite('GloballyMirroredIconsetSVG', 'DefaultContainer');
+          });
+
+          suite('and dir="rtl" on <html>', function() {
+            setup(function() {
+              document.documentElement.setAttribute('dir', 'rtl');
+            });
+
+            teardown(function() {
+              document.documentElement.removeAttribute('dir');
+            });
+
+            rtlSuite('GloballyMirroredIconsetSVG', 'DefaultContainer');
+          });
         });
       });
 


### PR DESCRIPTION
RTL detection based on CSS styles in subtrees has timing issues. In some circumstances, the value of the `direction` style property will be empty string while an element is booting up even though it should probably read as `"rtl"`.

This change proposes a fix where an addition configuration (`use-global-rtl-attribute`) of the iconset tells it to use the value of the `dir` attribute on either `<body>` or `<html>`, whichever is available.

Fixes #64 