### PR TITLE
check if svg.style exists before setting

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -254,7 +254,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         svg.setAttribute('focusable', 'false');
         // TODO(dfreedm): `pointer-events: none` works around https://crbug.com/370136
         // TODO(sjmiles): inline style may not be ideal, but avoids requiring a shadow-root
-        svg.style.cssText = cssText;
+
+        // check if style exists,
+        // in tor browsers high security settings the svg parser is disabled
+        // and the declaration fails
+        if (svg.style) {
+          svg.style.cssText = cssText;
+        }
         svg.appendChild(content).removeAttribute('id');
         return svg;
       }


### PR DESCRIPTION
In tor browsers high security settings the svg parser is disabled so declaring styles on the newly created svg element throws an error and breaks the whole application.