### PR TITLE
Fix: Large iconsets rendering

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -196,7 +196,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._meta.key = this.name;
       this._meta.value = this;
 
-      this.async(function() {
+      // Give time for icons to be added
+      Polymer.RenderStatus.afterNextRender(this, () => {
         this.fire('iron-iconset-added', this, {node: window});
       });
     },


### PR DESCRIPTION
Fixes #66 

When just using `this.async` with a large import tree, `this._createIconMap()` returns an empty object.
When using `Polymer.RenderStatus.afterNextRender`, `this._createIconMap()` returns the expected icons.

This feels like a better solution than waiting for the entire `document#DOMContentLoaded` event suggested in #77 

Will add tests and update changelog after some more testing and initial feedback.