### PR TITLE
Setting the transform-origin to resolve shadow RTL mirroring

### DIFF
--- a/iron-iconset-svg.html
+++ b/iron-iconset-svg.html
@@ -246,7 +246,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             cssText = 'pointer-events: none; display: block; width: 100%; height: 100%;';
 
         if (mirrorAllowed && content.hasAttribute('mirror-in-rtl')) {
-          cssText += '-webkit-transform:scale(-1,1);transform:scale(-1,1);';
+          cssText += '-webkit-transform:scale(-1,1);transform:scale(-1,1);transform-origin:center;';
         }
 
         svg.setAttribute('viewBox', viewBox);


### PR DESCRIPTION
This fixes #80 and an issue with icons in RTL being mirrored around the incorrect origin on browsers which support native shadow DOM.

(sample code in #80)

Before:
![iconset-rtl](https://user-images.githubusercontent.com/5491151/35463848-ca21603e-02c0-11e8-9d57-9a4762eca2b4.png)

After:
![iconset-rtl-fixed](https://user-images.githubusercontent.com/5491151/35463890-0c5be320-02c1-11e8-95d9-959b4c243909.png)
