### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-iconset-svg.js
+++ b/iron-iconset-svg.js
@@ -50,6 +50,7 @@ import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
  */
 Polymer({
   is: 'iron-iconset-svg',
+  _template: null,
 
   properties: {
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalize as part of cl/218551336